### PR TITLE
Update file-provider.toml

### DIFF
--- a/example_pihole/FileProvider/file-provider.toml
+++ b/example_pihole/FileProvider/file-provider.toml
@@ -21,7 +21,8 @@
       entryPoints = ["web-secure"]
       service = "service-plex"
       rule = "Host(`plex.example.org`)"     #Cambiare con il proprio dominio
-      certresolver="certificato"
+      [http.routers.plex.tls]
+        certresolver="certificato"
       [[http.routers.plex.tls.domains]]
         main = "*.example.org"              #Cambiare con il proprio dominio
 


### PR DESCRIPTION
Thanks for this example! Just what I searched for.
Gracias para este ejemplo! :)

I think you're missing a level: [http.routers.plex.tls] where certresolver should reside in. It took me some time to find the error with version 2.4 of Traefik.